### PR TITLE
Use tsconfig path mapping to configure module-name-> location, to be …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ Thumbs.db
 # test subproject and demo
 /demo
 /tests/dist
-/tests/src/app/lib
+/tests/src/lib/
 /tests/tmp
 /tests/node_modules
 /tests/.idea
@@ -47,4 +47,3 @@ Thumbs.db
 /tests/typings
 /tests/e2e/*.js
 /tests/e2e/*.map
-

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:aot": "ngc -p tsconfig.json",
     "build:jit": "tsc -p tsconfig.json",
     "build": "yarn run clean && yarn build:aot",
-    "test:updateLib": "cd tests/src/app && rm -rf ./lib && cp -r ../../../src/ ./lib && cd -",
+    "test:updateLib": "cd tests/src && rm -rf ./lib && mkdir -p lib/@plone/ && cp -r ../../src/ lib/@plone/restapi-angular/ && cd -",
     "test": "yarn test:updateLib && cd tests && ng test --single-run --code-coverage"
   },
   "repository": {

--- a/tests/src/app/app.component.spec.ts
+++ b/tests/src/app/app.component.spec.ts
@@ -6,7 +6,7 @@ import {
 import { Component } from '@angular/core';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 import { APP_BASE_HREF } from '@angular/common';
-import { RESTAPIModule } from './lib';
+import { RESTAPIModule } from '@plone/restapi-angular';
 
 import { AppComponent } from './app.component';
 import { CustomViewView } from './custom';

--- a/tests/src/app/app.component.ts
+++ b/tests/src/app/app.component.ts
@@ -1,8 +1,8 @@
 import { Component } from '@angular/core';
-import { PloneViews, Services } from './lib';
+import { PloneViews, Services } from '@plone/restapi-angular';
 
 import { CustomViewView } from './custom';
-import { AuthenticatedStatus, LoadingStatus } from './lib/interfaces';
+import { AuthenticatedStatus, LoadingStatus } from '@plone/restapi-angular';
 
 @Component({
   selector: 'app-root',

--- a/tests/src/app/app.module.ts
+++ b/tests/src/app/app.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
-import { RESTAPIModule } from './lib';
+import { RESTAPIModule } from '@plone/restapi-angular';
 
 import { AppComponent } from './app.component';
 import { CustomViewView } from './custom';

--- a/tests/src/app/custom/index.ts
+++ b/tests/src/app/custom/index.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
-import { GlobalNavigation, Breadcrumbs } from '../lib';
-import { ViewView } from '../lib';
+import { GlobalNavigation, Breadcrumbs } from '@plone/restapi-angular';
+import { ViewView } from '@plone/restapi-angular';
 
 @Component({
   selector: 'custom-breadcrumbs',

--- a/tests/src/tsconfig.app.json
+++ b/tests/src/tsconfig.app.json
@@ -2,9 +2,12 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/app",
+    "baseUrl": "./",
     "module": "es2015",
-    "baseUrl": "",
-    "types": []
+    "types": [],
+    "paths": {
+      "@plone/restapi-angular": ["lib/@plone/restapi-angular"]
+    }
   },
   "exclude": [
     "test.ts",

--- a/tests/src/tsconfig.spec.json
+++ b/tests/src/tsconfig.spec.json
@@ -2,13 +2,16 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
+    "baseUrl": "./",
     "module": "commonjs",
     "target": "es5",
-    "baseUrl": "",
     "types": [
       "jasmine",
       "node"
-    ]
+    ],
+    "paths": {
+      "@plone/restapi-angular": ["lib/@plone/restapi-angular"]
+    }
   },
   "files": [
     "test.ts"

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,7 +2,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
-    "baseUrl": "src",
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",


### PR DESCRIPTION
…able to use the real module name in imports.

See https://github.com/plone/plone.restapi-angular/issues/15