### PR TITLE
Fix missing active links in global navigation, bug introduced in 516f3d9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - new download directive attribute
 
+## Bug fixes
+
+- Fix missing active links in global navigation, bug introduced in 1.2.0 [Sune Brøndum Wøller]
+
 
 # 1.2.3 (2017-09-29)
 

--- a/src/components/global.navigation.ts
+++ b/src/components/global.navigation.ts
@@ -19,7 +19,6 @@ import { Observable } from 'rxjs/Observable';
 })
 export class GlobalNavigation extends TraversingComponent implements OnInit, OnDestroy {
 
-  target: Target | null = null;
   links: NavLink[] = [];
   navigationRefresh: Subscription;
 
@@ -36,14 +35,13 @@ export class GlobalNavigation extends TraversingComponent implements OnInit, OnD
       .mergeMap(() => component.services.resource.navigation())
       .subscribe((links: NavLink[]) => {
           component.links = links;
-          component.setActiveLinks();
         }
       )
 
   }
 
   onTraverse(target: Target) {
-    this.setActiveLinks();
+    this.setActiveLinks(target);
   }
 
   ngOnDestroy() {
@@ -52,8 +50,7 @@ export class GlobalNavigation extends TraversingComponent implements OnInit, OnD
     }
   }
 
-  private setActiveLinks() {
-    const target = this.target;
+  private setActiveLinks(target: Target) {
     if (!target) {
       return;
     }


### PR DESCRIPTION
Target in global.navigation.ts -> setActiveLinks was always null, so setActiveLinks always returned with no effect.
The pattern elsewhere in the code is to use the target in onTraverse only to set other state (not to keep it as part of the component state).
So we use the same pattern here, passing target to setActiveLinks in onTraverse.
setActiveLinks needs not to be called in ngOnInit, since ngOnInit of the parent class
TraversingComponent triggers an onTraverse call when a target is ready (subscibing to target).