### PR TITLE
Compatibility with plone.restapi 1.0b1 and later: url has been rename…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - `review_state` is not a possible search *option* anymore. It is now a possible search criterion only.
 
+
 ## New features
 
 - Add plone-workflow component. [Thomas Desvenain]
@@ -34,6 +35,8 @@
 - We can configure request retries and auth token expiration delay. [Thomas Desvenain]
 
 - Add interface and helper for file field value upload. [Thomas Desvenain]
+
+- Compatibility with plone.restapi 1.0b1 and later: url has been renamed to @id on @navigation and @breadcrumb endpoints. Keep the url property on the NavLink interface to be backwards compatible. [Sune Wøller]
 
 ## Bug fixes
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,6 +30,7 @@ export interface Error {
  */
 
 export interface NavLink {
+  '@id': string;
   title: string;
   url: string;
   path: string;

--- a/src/services/resource.service.spec.ts
+++ b/src/services/resource.service.spec.ts
@@ -368,11 +368,11 @@ describe('ResourceService', () => {
       'items': [
         {
           'title': 'Home',
-          'url': 'http://fake/Plone'
+          '@id': 'http://fake/Plone'
         },
         {
           'title': 'Welcome to Plone',
-          'url': 'http://fake/Plone/front-page'
+          '@id': 'http://fake/Plone/front-page'
         }
       ]
     };
@@ -401,11 +401,11 @@ describe('ResourceService', () => {
       'items': [
         {
           'title': 'A folder',
-          'url': 'http://fake/Plone/a-folder'
+          '@id': 'http://fake/Plone/a-folder'
         },
         {
           'title': 'test',
-          'url': 'http://fake/Plone/a-folder/test'
+          '@id': 'http://fake/Plone/a-folder/test'
         }
       ]
     };

--- a/src/services/resource.service.ts
+++ b/src/services/resource.service.ts
@@ -18,7 +18,7 @@ import { ConfigurationService } from './configuration.service';
 
 interface NavigationItem {
   title: string;
-  url: string;
+  '@id': string;
   properties?: any;
 }
 
@@ -218,7 +218,8 @@ export class ResourceService {
   private linkFromItem(item: NavigationItem): NavLink {
     return {
       active: false,
-      path: this.configuration.urlToPath(item.url),
+      url: item['@id'],
+      path: this.configuration.urlToPath(item['@id']),
       ...item
     };
   }


### PR DESCRIPTION
…d to @id on @navigation and @breadcrumb endpoints. Keep the url property on the NavLink interface to be backwards compatible.